### PR TITLE
Set height of `.header-image` and `.background` progmatically because…

### DIFF
--- a/wp-content/themes/app/assets/js/app.js
+++ b/wp-content/themes/app/assets/js/app.js
@@ -1,0 +1,39 @@
+jQuery(function() {
+  var $ = jQuery;
+  var imageWidth = 1005;
+  var imageHeight =  1348;
+
+  function setWindowHeight() {
+    var height = $(window).height();
+    var width = $(window).width();
+
+    var w, h;
+    if (imageWidth / imageHeight > width / height) {
+      h = height;
+      w = height * imageWidth / imageHeight;
+    } else {
+      w = width;
+      h = width * imageHeight / imageWidth;
+    }
+
+    $('.header-container').css({
+      width: width,
+      height: height
+    });
+    $('.background').css({
+      backgroundSize: w + 'px ' + h + 'px'
+    });
+  }
+
+  function isIOS() {
+    var ua = navigator.userAgent;
+    return ua.indexOf('iPhone') >= 0
+      || ua.indexOf('iPad') >= 0
+      || navigator.userAgent.indexOf('iPod') >= 0;
+  }
+
+  $(window).on('orientationchange', setWindowHeight);
+  if (isIOS()) {
+    setWindowHeight();
+  }
+});

--- a/wp-content/themes/app/inc/head.php
+++ b/wp-content/themes/app/inc/head.php
@@ -13,6 +13,11 @@ function app_scripts() {
         '//stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js',
         array('jquery', 'popper')
     );
+    wp_enqueue_script(
+        'app-js',
+        get_theme_file_uri().'/assets/js/app.js',
+        array('jquery')
+    );
 }
 
 add_action( 'wp_enqueue_scripts', 'app_scripts' );

--- a/wp-content/themes/app/style.css
+++ b/wp-content/themes/app/style.css
@@ -13,6 +13,8 @@ Text Domain: app
 
 body {
   font-size: 14px;
+  height:100%;
+  background-color: #000;
 }
 
 h1, h2, h3, h4, h5, h6, h7, h8, h9, h10, h11, h12 {
@@ -35,7 +37,8 @@ a {
   z-index: -2;
   background-color: #000;
   background-size: cover;
-  background-image: url('./assets/images/bg.jpg')
+  background-image: url('./assets/images/bg.jpg');
+  background-repeat: no-repeat;
 }
 
 @media (max-width: 768px) {

--- a/wp-content/themes/app/style.css
+++ b/wp-content/themes/app/style.css
@@ -13,7 +13,6 @@ Text Domain: app
 
 body {
   font-size: 14px;
-  height:100%;
   background-color: #000;
 }
 
@@ -244,7 +243,7 @@ header {
   margin-bottom:37px;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 768px) and (orientation: portrait) {
   .header-container {
     height: calc(100vh);
     padding-top: 12%;


### PR DESCRIPTION
`calc(100vh)`はアドレスバーの有無で値が変わるようなので、最初にjavascriptで高さを取得して絶対値をセットするようにしました。

https://code.i-harness.com/ja/q/236499a

を参考にデバイスの大きさを元に外接した大きさで画像をセット。

- ロゴの１の調整もjavascript で大きさをとって調整。
- 横画面の時はロゴの上部のpaddingはなくすようにした。