### PR TITLE
clear footer's spinLogo blueline

### DIFF
--- a/wp-content/themes/app/style.css
+++ b/wp-content/themes/app/style.css
@@ -116,6 +116,7 @@ a {
 .footer_item_spinIcon:hover {
   filter:alpha(opacity=80);
   opacity:0.8;
+  outline:none
 }
 
 .spinIcon {


### PR DESCRIPTION
フッターのスピンコースターロゴをマウスオーバーすると青い下線が出ていたので消しました